### PR TITLE
Updated AAPT file locations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@
 buildscript {
     repositories {
         jcenter()
+        google() //Updating project as per Google specifications
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:1.3.0'
@@ -15,6 +16,7 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        google() //updating project as per Google specifications
     }
 }
 


### PR DESCRIPTION
Google recently updated the AAPT specifications and moved the locations to their Maven repository. I found this out the hard way when this app wouldn't run. This pull request is similar to #9 but I didn't need to add anything extra other than updating the build.gradle file in the project root, so this can be the "quick and dirty fix" method to just get the app working.